### PR TITLE
Discard bad data returned by the API (valeur=-1)

### DIFF
--- a/phpLinkyAPI.php
+++ b/phpLinkyAPI.php
@@ -35,6 +35,8 @@ class Linky{
         $end = count($data);
         for($i=$end-1; $i>=$end-48; $i--)
         {
+            if( $data[$i]['valeur'] === -1 )
+                continue;
             $valeur = $data[$i]['valeur'].'kW';
 
             $thisHour = clone $startHour;
@@ -72,6 +74,8 @@ class Linky{
         $data = $result['graphe']['data'];
         foreach ($data as $day)
         {
+            if( $day['valeur'] === -1 )
+                continue;
             $valeur = $day['valeur'];
             if ($valeur == -2) $valeur = null;
             else $valeur .= 'kWh';
@@ -103,6 +107,8 @@ class Linky{
         $data = $result['graphe']['data'];
         foreach ($data as $month)
         {
+            if( $month['valeur'] === -1 )
+                continue;
             $valeur = $month['valeur'];
             if ($valeur == -2) $valeur = null;
             else $valeur .= 'kW';
@@ -137,6 +143,8 @@ class Linky{
         $fromYear->modify('- '.$c.' year');
         foreach ($data as $year)
         {
+            if( $year['valeur'] === -1 )
+                continue;
             $valeur = $year['valeur'];
             if ($valeur == -2) $valeur = null;
             else $valeur .= 'kW';


### PR DESCRIPTION
Bonjour,
Parfois l'API injecte parfois des valeurs de consommation à "-1" dans les $result['graphe']['data']. Ça crée des décalages dans le traitement des données retournées par getData_perXXX. En ignorant ces valeurs, les décalages disparaissent.
Semble résoudre les problèmes 6 et 7.
Merci pour cet outil